### PR TITLE
Update sitemap generator for creating bilingual sites

### DIFF
--- a/contents/index.json
+++ b/contents/index.json
@@ -9,5 +9,9 @@
     "url": "https://capra314cabra.github.io/index.html",
     "image": "https://capra314cabra.github.io/Title.png",
     "description": "This is capra314cabra's website. It contains many contents and I hope it will help you.",
-    "site_name": "new Capra as IProgrammer"
+    "site_name": "new Capra as IProgrammer",
+
+    "bilingual": [
+        
+    ]
 }

--- a/scripts/html_builder.py
+++ b/scripts/html_builder.py
@@ -47,7 +47,7 @@ for file in pattern:
 
     # Add this to the consists of sitemap generator
     relative_path = "https://capra314cabra.github.io/" + os.path.basename(file)
-    sitemap_generator.add(relative_path, settingData["lastdate"], settingData["priority"])
+    sitemap_generator.add(relative_path, settingData["lastdate"], settingData["priority"], settingData["bilingual"])
 
     # Concatenate header and footer
     file_content = header_contents + file_content + footer_contents

--- a/scripts/sitemap_generator.py
+++ b/scripts/sitemap_generator.py
@@ -8,23 +8,29 @@ class SiteMapGenerator:
     def __init__(self):
         pass
 
-    def add(self, file_path, last_date, priority = 0.5):
-        self.files.append([file_path, last_date, priority])
+    def add(self, file_path, last_date, priority = 0.5, bilingual = []):
+        self.files.append([file_path, last_date, priority, bilingual])
 
     def bake(self):
         with open(self.OUTPUT_PATH, "w") as f:
-            f.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
-            f.write("<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">")
+            f.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
+            f.write("<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\"\n")
+            f.write("xmlns:xhtml=\"http://www.w3.org/1999/xhtml\">\n")
             
             for file in self.files:
-                f.write("<url>")
-                [file_path, last_date, priority] = file
-                f.write("<loc>" + file_path + "</loc>")
-                f.write("<lastmod>" + last_date + "</lastmod>")
-                f.write("<priority>" + str(priority) + "</priority>")
-                f.write("</url>")
+                f.write("<url>\n")
+                [file_path, last_date, priority, bilingual] = file
+                f.write("\t<loc>" + file_path + "</loc>\n")
+                f.write("\t<lastmod>" + last_date + "</lastmod>\n")
+                f.write("\t<priority>" + str(priority) + "</priority>\n")
+                for lang in bilingual:
+                    f.write("\t\t<xhtml:link rel=\"alternate\"\n")
+                    f.write("\t\threflang=\""+ lang["lang"] + "\"\n")
+                    f.write("\t\thref=\""+ lang["link"] + "\"\n")
+                    f.write("\t\t/>\n")
+                f.write("</url>\n")
 
-            f.write("</urlset>")
+            f.write("</urlset>\n")
 
     def additionalAdd(self):
         # Add files here.


### PR DESCRIPTION
Now, there is json files which are able to contain a item named "bilingual".
The contents, "bilingual" is also formated as the followings:
``` JSON
"bilingual": [
  {
    "lang": "jp",
    "link": "./some.jp.html",
  },
  {
    "lang": "en",
    "link": "./some.en.html",
  },
]
```